### PR TITLE
Increased brightness of sideBar.foreground

### DIFF
--- a/themes/Deeold-color-theme.json
+++ b/themes/Deeold-color-theme.json
@@ -197,7 +197,7 @@
 		// sidebar
 		"sideBar.background": "#121824",
 		"sideBar.border": "#27334D",
-		"sideBar.foreground": "#58678A",
+		"sideBar.foreground": "#8298cc",
 		"sideBarSectionHeader.background": "#1e263a",
 		"sideBarSectionHeader.foreground": "#98a2ad",
 		"sideBarTitle.foreground": "#98a2ad",


### PR DESCRIPTION
I like your theme, but I've some trouble to read the sidebar items when inactive. 

![image](https://user-images.githubusercontent.com/1702738/65348447-7e06a500-dbe1-11e9-94e1-201c155abddc.png)

And after the change:

![image](https://user-images.githubusercontent.com/1702738/65348478-95459280-dbe1-11e9-9fb0-0e4585f64a7f.png)

Thanks in advance for considering this Pull Request.